### PR TITLE
Integration tests

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,0 +1,37 @@
+name: Tests on Docker
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+
+      - name: Pull example spider
+        run: docker pull ghcr.io/q-m/scrapyd-k8s-spider-example
+
+      - name: Run scrapyd-k8s
+        run: |
+          cp scrapyd_k8s.sample-docker.conf scrapyd_k8s.conf
+          python -m scrapyd_k8s &
+          while ! nc -q 1 localhost 6800 </dev/null; do sleep 1; done
+          curl http://localhost:6800/daemonstatus.json
+
+      - name: Run tests
+        run: pytest -vv test_api.py

--- a/.github/workflows/test-k8s.yml
+++ b/.github/workflows/test-k8s.yml
@@ -1,0 +1,47 @@
+name: Tests on Kubernetes
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+
+      - name: Prepare Kubernetes environment
+        run: |
+          kubectl create secret generic example-env-secret --from-literal=FOO_1=bar
+          kubectl create configmap example-env-configmap --from-literal=FOO_2=baz
+          # already pull image so we don't have to wait for it later
+          minikube image pull ghcr.io/q-m/scrapyd-k8s-spider-example:latest
+
+      - name: Run scrapyd-k8s
+        run: |
+          cp scrapyd_k8s.sample-k8s.conf scrapyd_k8s.conf
+          python -m scrapyd_k8s &
+          while ! nc -q 1 localhost 6800 </dev/null; do sleep 1; done
+          curl http://localhost:6800/daemonstatus.json
+
+      - name: Run tests
+        run: |
+          TEST_MAX_WAIT=60 \
+          TEST_AVAILABLE_VERSIONS=latest,`skopeo list-tags docker://ghcr.io/q-m/scrapyd-k8s-spider-example | jq -r '.Tags | map(select(. != "latest" and (startswith("sha-") | not))) | join(",")'` \
+          pytest -vv --color=yes test_api.py

--- a/.github/workflows/test-manifest.yml
+++ b/.github/workflows/test-manifest.yml
@@ -1,0 +1,61 @@
+name: Test Kubernetes manifest
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: test:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+
+      - name: Deploy to minikube
+        run: |
+          minikube image load test:latest
+          # already pull image so we don't have to wait for it later
+          minikube image pull ghcr.io/q-m/scrapyd-k8s-spider-example:latest
+          # load manifest
+          sed -i 's/\(imagePullPolicy:\s*\)\w\+/\1Never/' kubernetes.yaml
+          sed -i 's/\(image:\s*\)ghcr\.io\/q-m\/scrapyd-k8s:/\1test:/' kubernetes.yaml
+          sed -i 's/\(type:\s*\)ClusterIP/\1NodePort/' kubernetes.yaml
+          kubectl create -f kubernetes.yaml
+          # and wait for scrapyd-k8s to become ready
+          kubectl wait --for=condition=Available deploy/scrapyd-k8s --timeout=60s
+          curl --retry 10 --retry-delay 2 --retry-all-errors `minikube service scrapyd-k8s --url`/daemonstatus.json
+
+      - name: Run tests
+        run: |
+          TEST_BASE_URL=`minikube service scrapyd-k8s --url` \
+          TEST_MAX_WAIT=60 \
+          TEST_AVAILABLE_VERSIONS=latest,`skopeo list-tags docker://ghcr.io/q-m/scrapyd-k8s-spider-example | jq -r '.Tags | map(select(. != "latest" and (startswith("sha-") | not))) | join(",")'` \
+          pytest -vv --color=yes test_api.py

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ things out.
 
 ### Kubernetes
 
-1. Create the spider namespace: `kubectl create namespace scrapyd`
-2. Adapt the spider configuration in [`kubernetes.yaml`](./kubernetes.yaml) (`scrapyd_k8s.conf` in configmap)
-3. Create the resources: `kubectl create -f kubernetes.yaml`
+1. Adapt the spider configuration in [`kubernetes.yaml`](./kubernetes.yaml) (`scrapyd_k8s.conf` in configmap)
+2. Create the resources: `kubectl create -f kubernetes.yaml`
 
 You'll be able to talk to the `scrapyd-k8s` service on port `6800`.
 
@@ -134,7 +133,7 @@ curl 'http://localhost:6800/listspiders.json?project=example&_version=latest'
 ```
 
 > ```json
-> {"spiders":["quotes"],"status":"ok"}
+> {"spiders":["quotes","static"],"status":"ok"}
 > ```
 
 ```sh

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -72,12 +72,13 @@ data:
     repository   = scrapyd_k8s.repository.Remote
     launcher     = scrapyd_k8s.launcher.K8s
 
-    namespace    = scrapyd
+    namespace    = default
 
     # This is an example spider that should work out of the box.
-    # Adapt the spider config to your use-case, with an otherwise unused secret.
+    # Adapt the spider config to your use-case.
     [project.example]
     env_secret   = spider-example-env
+    env_config   = spider-example-env
     repository   = ghcr.io/q-m/scrapyd-k8s-spider-example
 
     # It is strongly recomended to set resource requests and limits on production.
@@ -96,6 +97,15 @@ metadata:
     app.kubernetes.io/name: spider-example
 stringData:
   FOO_API_KEY: "1234567890abcdef"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spider-example-env
+  labels:
+    app.kubernetes.io/name: spider-example
+data:
+  BAR_VALUE: "baz"
 ---
 apiVersion: v1
 kind: Service
@@ -117,20 +127,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: scrapyd-k8s
-  namespace: scrapyd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: scrapyd-k8s
-  namespace: scrapyd
 rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods/exec"]
-    verbs: ["create"]
+    verbs: ["get"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "create", "delete"]
@@ -139,7 +147,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: scrapyd-k8s
-  namespace: scrapyd
 subjects:
   - kind: ServiceAccount
     name: scrapyd-k8s

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest>=6.0.0
+requests>=2.0.0

--- a/scrapyd_k8s.sample-k8s.conf
+++ b/scrapyd_k8s.sample-k8s.conf
@@ -14,9 +14,10 @@ repository   = scrapyd_k8s.repository.Remote
 launcher     = scrapyd_k8s.launcher.K8s
 
 # Namespace to work in (needs to exist).
-namespace    = scrapyd
+# Check RBAC if you run scrapyd-k8s in a different namespace than spiders.
+namespace    = default
 # Optional pull secret, in case you have private spiders.
-pull_secret  = ghcr-registry
+#pull_secret  = ghcr-registry
 
 # For each project, define a project section.
 # This contains a repository that points to the remote container repository.

--- a/scrapyd_k8s/api.py
+++ b/scrapyd_k8s/api.py
@@ -33,7 +33,7 @@ def api_schedule():
         return error('project missing in form parameters', status=400)
     project = config.project(project_id)
     if not project:
-        return error('project not found in configuration', status=404)
+        return error('project not found in configuration', status=400)
     spider = request.form.get('spider')
     if not spider:
         return error('spider not found in form parameters', status=400)
@@ -55,7 +55,7 @@ def api_cancel():
     job_id = request.form.get('job')
     if not job_id:
         return error('job missing in form parameters', status=400)
-    signal = request.form.get('signal', 'TERM')
+    signal = request.form.get('signal', 'TERM') # TODO validate signal?
     prevstate = launcher.cancel(project_id, job_id, signal)
     if not prevstate:
         return error('job not found', status=404)

--- a/scrapyd_k8s/launcher/docker.py
+++ b/scrapyd_k8s/launcher/docker.py
@@ -38,6 +38,8 @@ class Docker:
             command=['scrapy', 'crawl', spider, *_args, *_settings],
             environment=env,
             labels={
+                self.LABEL_PROJECT: project.id(),
+                self.LABEL_SPIDER: spider,
                 self.LABEL_JOB_ID: job_id,
             },
             name='_'.join(['scrapyd', project.id(), job_id]),

--- a/test_api.py
+++ b/test_api.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+import os
+import pytest
+import requests
+import time
+
+
+BASE_URL = os.getenv('TEST_BASE_URL', 'http://localhost:6800')
+AVAIL_PROJECTS = os.getenv('TEST_AVAILABLE_PROJECTS', 'example').split(',')
+AVAIL_VERSIONS = os.getenv('TEST_AVAILABLE_VERSIONS', 'latest').split(',')
+AVAIL_SPIDERS = os.getenv('TEST_AVAILABLE_SPIDERS', 'quotes,static').split(',')
+RUN_PROJECT = os.getenv('TEST_RUN_PROJECT', 'example')
+RUN_VERSION = os.getenv('TEST_RUN_VERSION', 'latest')
+RUN_SPIDER = os.getenv('TEST_RUN_SPIDER', 'static')
+MAX_WAIT = int(os.getenv('TEST_MAX_WAIT', '6'))
+STATIC_SLEEP = float(os.getenv('TEST_STATIC_SLEEP', '2'))
+
+
+def test_root_ok():
+    response = requests.get(BASE_URL)
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
+    assert 'scrapyd-k8s' in response.text
+    assert '</html>' in response.text
+
+
+def test_healthz_ok():
+    response = requests.get(BASE_URL + '/healthz')
+    assert response.status_code == 200
+
+
+def test_daemonstatus_ok():
+    response = requests.get(BASE_URL + '/daemonstatus.json')
+    assert_response_ok(response)
+    # TODO assert response.json() == { 'status': 'ok', ... }
+
+
+def test_listprojects_ok():
+    response = requests.get(BASE_URL + '/listprojects.json')
+    assert_response_ok(response)
+    assert response.json() == { 'status': 'ok', 'projects': AVAIL_PROJECTS }
+
+
+def test_listversions_ok():
+    response = requests.get(BASE_URL + '/listversions.json?project=' + RUN_PROJECT)
+    assert_response_ok(response)
+    assert response.json() == { 'status': 'ok', 'versions': AVAIL_VERSIONS }
+
+def test_listversions_project_missing():
+    response = requests.get(BASE_URL + '/listversions.json')
+    assert_response_error(response, 400)
+
+def test_listversions_project_not_found():
+    response = requests.get(BASE_URL + '/listversions.json?project=' + 'nonexistant')
+    assert_response_error(response, 404)
+
+
+def test_listspiders_ok():
+    response = requests.get(BASE_URL + '/listspiders.json?project=' + RUN_PROJECT + '&_version=' + RUN_VERSION)
+    assert_response_ok(response)
+    assert response.json() == { 'status': 'ok', 'spiders': AVAIL_SPIDERS }
+
+def test_listspiders_ok_without_version():
+    response = requests.get(BASE_URL + '/listspiders.json?project=' + RUN_PROJECT)
+    assert_response_ok(response)
+    assert response.json() == { 'status': 'ok', 'spiders': AVAIL_SPIDERS }
+
+def test_listspiders_project_missing():
+    response = requests.get(BASE_URL + '/listspiders.json')
+    assert_response_error(response, 400)
+
+def test_listspiders_project_not_found():
+    response = requests.get(BASE_URL + '/listspiders.json?project=' + 'nonexistant' + '&_version=' + RUN_VERSION)
+    assert_response_error(response, 404)
+
+def test_listspiders_version_not_found():
+    response = requests.get(BASE_URL + '/listspiders.json?project=' + RUN_PROJECT + '&_version=' + 'nonexistant')
+    assert_response_error(response, 404)
+
+
+def test_schedule_project_missing():
+    response = requests.post(BASE_URL + '/schedule.json', data={})
+    assert_response_error(response, 400)
+
+def test_schedule_project_not_found():
+    response = requests.post(BASE_URL + '/schedule.json', data={ 'project': 'nonexistant' })
+    assert_response_error(response, 400)
+
+def test_schedule_spider_missing():
+    response = requests.post(BASE_URL + '/schedule.json', data={ 'project': RUN_PROJECT })
+    assert_response_error(response, 400)
+
+# scheduling a non-existing spider will try to start it, so no error
+# scheduling a non-existing project version will try to start it, so no error
+
+
+def test_cancel_project_missing():
+    response = requests.post(BASE_URL + '/cancel.json', data={})
+    assert_response_error(response, 400)
+
+# we don't test cancelling a spider from a project not in the config file
+
+def test_cancel_jobid_missing():
+    response = requests.post(BASE_URL + '/cancel.json', data={ 'project': RUN_PROJECT })
+    assert_response_error(response, 400)
+
+# TODO test cancel with invalid signal (currently returns server error, could be improved)
+
+
+def test_scenario_regular_ok():
+    scenario_regular({
+        'project': RUN_PROJECT, '_version': RUN_VERSION, 'spider': RUN_SPIDER,
+        'setting': 'STATIC_SLEEP=%d' % STATIC_SLEEP
+    })
+
+def test_scenario_regular_ok_without_version():
+    scenario_regular({
+        'project': RUN_PROJECT, 'spider': RUN_SPIDER,
+        'setting': 'STATIC_SLEEP=%d' % STATIC_SLEEP
+    })
+
+# TODO test_scenario_cancel_scheduled_ok (needs a way to make sure a job is not running yet)
+
+def test_scenario_cancel_running_finished_ok():
+    assert_listjobs()
+    # schedule a new job and wait until it is running
+    response = requests.post(BASE_URL + '/schedule.json', data={
+        'project': RUN_PROJECT, '_version': RUN_VERSION, 'spider': RUN_SPIDER,
+        'setting': 'STATIC_SLEEP=%d' % (STATIC_SLEEP * 5)
+    })
+    assert_response_ok(response)
+    jobid = response.json()['jobid']
+    assert jobid is not None
+    # wait until the job is running
+    listjobs_wait(jobid, 'running')
+    # cancel the job, with the kill signal to make it stop right away
+    response = requests.post(BASE_URL + '/cancel.json', data={
+        'project': RUN_PROJECT, 'job': jobid, 'signal': 'KILL'
+    })
+    assert_response_ok(response)
+    assert response.json() == { 'status': 'ok', 'prevstate': 'running' }
+    # wait until the job has stopped
+    listjobs_wait(jobid, 'finished')
+    jobinfo = assert_listjobs(finished=jobid)
+    assert jobinfo == { 'id': jobid, 'project': RUN_PROJECT, 'spider': RUN_SPIDER, 'state': 'finished' }
+    # then cancel it again, though nothing would happen
+    response = requests.post(BASE_URL + '/cancel.json', data={ 'project': RUN_PROJECT, 'job': jobid })
+    assert_response_ok(response)
+    assert response.json() == { 'status': 'ok', 'prevstate': 'finished' }
+
+
+def scenario_regular(schedule_args):
+    assert_listjobs()
+    # schedule a job
+    response = requests.post(BASE_URL + '/schedule.json', data=schedule_args)
+    assert_response_ok(response)
+    jobid = response.json()['jobid']
+    assert jobid is not None
+    # wait until the job is running
+    listjobs_wait(jobid, 'running')
+    jobinfo = assert_listjobs(running=jobid)
+    assert jobinfo == { 'id': jobid, 'project': RUN_PROJECT, 'spider': RUN_SPIDER, 'state': 'running' }
+    # wait until the job has finished
+    listjobs_wait(jobid, 'finished')
+    # check listjobs output
+    jobinfo = assert_listjobs(finished=jobid)
+    assert jobinfo == { 'id': jobid, 'project': RUN_PROJECT, 'spider': RUN_SPIDER, 'state': 'finished' }
+
+def assert_response_ok(response):
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json()['status'] == 'ok'
+
+def assert_response_error(response, status):
+    assert response.status_code == status
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json()['status'] == 'error'
+    assert response.json()['message'] is not None
+
+def assert_listjobs(pending=None, running=None, finished=None):
+    response = requests.get(BASE_URL + '/listjobs.json')
+    assert_response_ok(response)
+    if pending:
+        assert len(response.json()['pending']) == 1
+        assert response.json()['pending'][0]['id'] == pending
+        return response.json()['pending'][0]
+    else:
+        assert response.json()['pending'] == []
+    if running:
+        assert len(response.json()['running']) == 1
+        assert response.json()['running'][0]['id'] == running
+        return response.json()['running'][0]
+    else:
+        assert response.json()['running'] == []
+    # finished may contain other jobs
+    if finished:
+        matches = [j for j in response.json()['finished'] if j['id'] == finished]
+        assert len(matches) == 1
+        return matches[0]
+
+def listjobs_wait(jobid, state):
+    started = time.monotonic()
+    while time.monotonic() - started < MAX_WAIT:
+        response = requests.get(BASE_URL + '/listjobs.json')
+        assert_response_ok(response)
+        for j in response.json()[state]:
+            if j['id'] == jobid:
+                return True
+        time.sleep(0.5)
+    assert False, 'Timeout waiting for job state change'


### PR DESCRIPTION
- [x] Add initial tests
- [x] CI for Docker (running locally)
- [x] CI for Kubernetes (running locally)
- [x] Fix jobs on Kubernetes CI being stuck in _scheduled_
- [x] CI for running scrapyd-k8s in Kubernetes (testing `kubernetes.yaml`)
- [x] Add spider to example spider project that returns static data (or run from cache)
- [x] ~~Finish tests~~ --> as part of other issues

Possible next steps:
- Test job cancel while job is pending (needs something to create a job without starting it)
- Test http auth (needs config file change and daemon restart, so perhaps different method)
- Test if values in secret and configmap are passed through to the spider (*)
- Test if pull secret is picked up
- Test if schedule [spider arguments](https://docs.scrapy.org/en/latest/topics/spiders.html#spiderargs) are passed through to the spider (*)
- Test if schedule [spider settings](https://docs.scrapy.org/en/latest/topics/settings.html) are passed through to the spider (*)

(*) May need changes to the example spider, e.g. returning `ENV`, spider settings and spider arguments in static spider or a new debug spider or so.