### PR TITLE
Add proper error messages for unsupported endpoints (q-m#16)

### DIFF
--- a/scrapyd_k8s/api.py
+++ b/scrapyd_k8s/api.py
@@ -103,6 +103,21 @@ def api_listjobs():
     # TODO perhaps remove state from jobs
     return { 'status': 'ok', 'pending': pending, 'running': running, 'finished': finished }
 
+@app.post("/addversion.json")
+def api_addversion():
+    return error("Not supported, by design. If you want to add a version, "
+                 "add a Docker image to the repository.", status=501)
+
+@app.post("/delversion.json")
+def api_delversion():
+    return error("Not supported, by design. If you want to delete a version, "
+                 "remove the corresponding Docker image from the repository.", status=501)
+
+@app.post("/delproject.json")
+def api_delproject():
+    return error("Not supported, by design. If you want to delete a project, "
+                 "remove it from the configuration file.", status=501)
+
 # middleware that adds "node_name" to each response if it is a JSON
 @app.after_request
 def after_request(response: Response):
@@ -126,7 +141,7 @@ def run():
     # where to listen
     host = scrapyd_config.get('bind_address', '127.0.0.1')
     port = scrapyd_config.get('http_port', '6800')
-    
+
     # authentication
     config_username = scrapyd_config.get('username')
     config_password = scrapyd_config.get('password')

--- a/test_api.py
+++ b/test_api.py
@@ -83,6 +83,18 @@ def test_listspiders_version_not_found():
     response = requests.get(BASE_URL + '/listspiders.json?project=' + RUN_PROJECT + '&_version=' + 'nonexistant')
     assert_response_error(response, 404)
 
+def test_addversion():
+    response = requests.post(BASE_URL + '/addversion.json')
+    assert_response_error(response, 501)
+
+def test_delversion():
+    response = requests.post(BASE_URL + '/delversion.json')
+    assert_response_error(response, 501)
+
+def test_delproject():
+    response = requests.post(BASE_URL + '/delproject.json')
+    assert_response_error(response, 501)
+
 def test_schedule_project_missing():
     response = requests.post(BASE_URL + '/schedule.json', data={})
     assert_response_error(response, 400)


### PR DESCRIPTION
I used http status 501 (Not Implemented) for this, but if you think 404 is better, I'll change it.

I took the messages sent with the error from the README and added basic tests.

Fixes #16 