### PR TITLE
added functionality to remove successfully ploaded files; additionaly…

### DIFF
--- a/scrapyd_k8s/joblogs/log_handler_k8s.py
+++ b/scrapyd_k8s/joblogs/log_handler_k8s.py
@@ -285,8 +285,14 @@ class KubernetesJobLogHandler:
                     if log_filename is not None and os.path.isfile(log_filename) and os.path.getsize(log_filename) > 0:
                         if self.object_storage_provider.object_exists(job_id):
                             logger.info(f"Log file for job '{job_id}' already exists in storage.")
+                            if os.path.exists(log_filename):
+                                os.remove(log_filename)
+                                logger.info(
+                                    f"Removed local log file '{log_filename}' since it already exists in storage.")
                         else:
                             self.object_storage_provider.upload_file(log_filename)
+                            os.remove(log_filename)
+                            logger.info(f"Removed local log file '{log_filename}' after successful upload.")
                     else:
                         logger.info(f"Logfile not found for job '{job_id}'")
             else:


### PR DESCRIPTION
Cherry-picked changes (1 last commit from 668-joblogs branch):

Added logic to remove files:

After file was successfully uploaded to the S3-like-storage the file in the volume will be removed;
When code receives events from other existing jobs on the cluster it checks if files with its logs are present in the S3-like-storage, if not the code will attempt to collect logs, if the stdout is still available, if the file exists the code now checks if that file also still present in the volume and removes it since it is present in the S3-like-storage.
I think this functionality addresses your concerns.

