### PR TITLE
Configure joblogs storage (PR #34)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -46,7 +46,7 @@ For Kubernetes, it is important to set resource limits.
 TODO: explain how to set limits, with default, project and spider specificity.
 
 ### [joblogs] section
-* `logs_dir`     - a directory to store log files collected on k8s cluster (implemented only for Kubernetes). When configuring, keep in mind that in the Dockerfile the `USER` is set to `nobody` so not all directories are writable, but if you make a child directory under `/tmp` you won't encounter permission problems.
+* `logs_dir`     - a directory to store log files collected on k8s cluster (implemented only for Kubernetes). If you are using a Persistent Volume, keep in mind, that the provided path should be mounted in the deployment manifest.
 
 
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -46,7 +46,7 @@ For Kubernetes, it is important to set resource limits.
 TODO: explain how to set limits, with default, project and spider specificity.
 
 ### [joblogs] section
-* `logs_dir`     - a directory to store log files collected on k8s cluster (implemented only for Kubernetes). If you are using a Persistent Volume, keep in mind, that the provided path should be mounted in the deployment manifest.
+  * `logs_dir`     - a directory to store log files collected on k8s cluster (implemented only for Kubernetes). If you are using a Persistent Volume, keep in mind, that the provided path should be mounted in the deployment manifest. Read and write permissions should be granted to allow actions with log files in the provided directory, thus a [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) was added to the deployment manifest.
 
 
 

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -108,7 +108,7 @@ data:
     limits_memory = 0.5G
     
     [joblogs]
-    logs_dir = /data/scrapyd_k8s_logs
+    logs_dir = /data/joblogs
 ---
 apiVersion: v1
 kind: Secret
@@ -118,18 +118,6 @@ metadata:
     app.kubernetes.io/name: spider-example
 stringData:
   FOO_API_KEY: "1234567890abcdef"
-#---
-#apiVersion: v1
-#kind: PersistentVolume
-#metadata:
-#  name: pv-volume
-#spec:
-#  capacity:
-#    storage: 5Gi
-#  accessModes:
-#    - ReadWriteOnce
-#  hostPath:
-#    path: "/mnt/data"
 #---
 #apiVersion: v1
 #kind: PersistentVolumeClaim

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app.kubernetes.io/name: scrapyd-k8s
     spec:
+      securityContext:
+        fsGroup: 1000
       serviceAccountName: scrapyd-k8s
       containers:
         - image: ghcr.io/q-m/scrapyd-k8s:latest
@@ -106,7 +108,7 @@ data:
     limits_memory = 0.5G
     
     [joblogs]
-    logs_dir = /tmp/scrapyd_k8s_logs
+    logs_dir = /data/scrapyd_k8s_logs
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
adjust k8s yaml to provide a path for logs file generated by the jobogs feature; create an fsGroup to allow writing to the provided directory, adjust PVC manifest; alter cofig.md file by deleting a clause about /tmp dir since we have an appropriate security context now