### PR TITLE
47-joblogs-path

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -108,7 +108,7 @@ data:
     limits_memory = 0.5G
     
     [joblogs]
-    logs_dir = /tmp/joblogs
+    logs_dir = /data/joblogs
 ---
 apiVersion: v1
 kind: Secret

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -99,7 +99,7 @@ data:
     env_config   = spider-example-env
     repository   = ghcr.io/q-m/scrapyd-k8s-spider-example
 
-    # It is strongly recomended to set resource requests and limits on production.
+    # It is strongly recommended to set resource requests and limits on production.
     # They can be overridden on the project and spider level.
     [default.resources]
     requests_cpu = 0.2
@@ -108,7 +108,7 @@ data:
     limits_memory = 0.5G
     
     [joblogs]
-    logs_dir = /data/joblogs
+    logs_dir = /tmp/joblogs
 ---
 apiVersion: v1
 kind: Secret

--- a/scrapyd_k8s/joblogs/log_handler_k8s.py
+++ b/scrapyd_k8s/joblogs/log_handler_k8s.py
@@ -268,6 +268,8 @@ class KubernetesJobLogHandler:
             if pod.metadata.labels.get("org.scrapy.job_id"):
                 job_id = pod.metadata.labels.get("org.scrapy.job_id")
                 pod_name = pod.metadata.name
+                spider = pod.metadata.labels.get("org.scrapy.spider")
+                project = pod.metadata.labels.get("org.scrapy.project")
                 thread_name = f"{self.namespace}_{pod_name}"
                 if pod.status.phase == 'Running':
                     if (thread_name in self.watcher_threads
@@ -290,7 +292,7 @@ class KubernetesJobLogHandler:
                                 logger.info(
                                     f"Removed local log file '{log_filename}' since it already exists in storage.")
                         else:
-                            self.object_storage_provider.upload_file(log_filename)
+                            self.object_storage_provider.upload_file(project, spider, log_filename)
                             os.remove(log_filename)
                             logger.info(f"Removed local log file '{log_filename}' after successful upload.")
                     else:

--- a/scrapyd_k8s/object_storage/libcloud_driver.py
+++ b/scrapyd_k8s/object_storage/libcloud_driver.py
@@ -147,7 +147,6 @@ class LibcloudObjectStorage:
                 verify_hash=False,
                 headers=None
             )
-            logger.debug("HEY I AN UPLOADING")
             logger.info(f"Successfully uploaded '{object_name}' to container '{self._container_name}'.")
         except (ObjectError, ContainerDoesNotExistError, InvalidContainerNameError) as e:
             logger.exception(f"Error uploading the file '{object_name}': {e}")

--- a/scrapyd_k8s/object_storage/libcloud_driver.py
+++ b/scrapyd_k8s/object_storage/libcloud_driver.py
@@ -10,6 +10,7 @@ from libcloud.storage.types import (
 from libcloud.storage.providers import get_driver
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
 
 class LibcloudObjectStorage:
     """
@@ -113,14 +114,18 @@ class LibcloudObjectStorage:
         result = result.replace(r'\${', '${')
         return result
 
-    def upload_file(self, local_path):
+    def upload_file(self, project, spider, local_path):
         """
         Uploads a file to the object storage container.
 
         Parameters
         ----------
         local_path : str
-            The local file path of the file to be uploaded.
+            The job_id that is passed as a local path.
+        project : str
+            The name of the project.
+        spider : str
+            The name of the spider.
 
         Returns
         -------
@@ -130,7 +135,8 @@ class LibcloudObjectStorage:
         ----
         Logs information about the upload status or errors encountered.
         """
-        object_name = os.path.basename(local_path)
+        job_id = os.path.basename(local_path).replace('.txt', '')
+        object_name = f"logs/{project}/{spider}/{job_id}.log"
         try:
             container = self.driver.get_container(container_name=self._container_name)
             self.driver.upload_object(
@@ -141,6 +147,7 @@ class LibcloudObjectStorage:
                 verify_hash=False,
                 headers=None
             )
+            logger.debug("HEY I AN UPLOADING")
             logger.info(f"Successfully uploaded '{object_name}' to container '{self._container_name}'.")
         except (ObjectError, ContainerDoesNotExistError, InvalidContainerNameError) as e:
             logger.exception(f"Error uploading the file '{object_name}': {e}")


### PR DESCRIPTION
#47 
The new changes affect two methods:

KubernetesJobLogHandler.handle_events and LibcloudObjectStorage.upload_file

handle_events now extract two more labels from the job pod to identify project and spider names and then passes them to the upload_file function.

upload_file uses project name, spider name and extract job_id from a local_path parameter to construct a new object name that is used to create a specific directory like structure in the remote storage.