### PR TITLE
Add joblog label to job

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -46,6 +46,36 @@ For Kubernetes, it is important to set resource limits.
 TODO: explain how to set limits, with default, project and spider specificity.
 
 ### [joblogs] section
+
+The joblogs section is used to configure the job logs feature. It is not enabled by default, but can be activated if you
+choose to use it. The job logs feature allows you to collect logs from the Kubernetes cluster and store them in a specified
+directory. The logs are collected from the pods running on the cluster and can be compressed using a specified method.
+The job logs feature is implemented only for Kubernetes and is not available for Docker.
+
+When the log file was uploaded to the specified storage, the pod is labeled with org.scrapy.log_file_uploaded=true, it also
+contains labels to specify an end location of the log files in the storage.
+Since the label field has limitation in the number of symbols, an end location is split into several labels, each of them
+contains a part of the end location. The labels are named as follows:
+  * org.scrapy.project
+  * org.scrapy.spider
+  * org.scrapy.job_id
+  * org.scrapy.extension
+
+How can you build the end location from these labels? Complete the following line
+  * logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.`org.scrapy.extension` 
+
+**Important**: if you used the `compression_method` parameter, the extension of the log file then have two extensions. The
+first extension is `.log` and the second extension is extracted to the label `org.scrapy.extension`. 
+
+For example, if you used
+`compression_method = gzip`, the log file will be named as 
+  * logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.log.`org.scrapy.extension`
+
+If you haven't specified a compression method, then none was applied and the final location of the log file is
+* logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.`org.scrapy.extension`
+
+The joblogs section contains the following parameters:
+
   * `logs_dir`     - a directory to store log files collected on k8s cluster (implemented only for Kubernetes). If you are using a Persistent Volume, keep in mind, that the provided path should be mounted in the deployment manifest. Read and write permissions should be granted to allow actions with log files in the provided directory, thus a [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) was added to the deployment manifest.
   * `compression_method` - a method to compress log files. Available options are `gzip` `bzip2`, `lzma`, `brotli` and `none`. If no compression_method is provided, it defaults to `none`.
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -50,7 +50,17 @@ TODO: explain how to set limits, with default, project and spider specificity.
 The joblogs section is used to configure the job logs feature. It is not enabled by default, but can be activated if you
 choose to use it. The job logs feature allows you to collect logs from the Kubernetes cluster and store them in a specified
 directory. The logs are collected from the pods running on the cluster and can be compressed using a specified method.
+If the log file was successfully uploaded to the remote storage, the pod is labeled with `org.scrapy.log_file_uploaded: true`.
 The job logs feature is implemented only for Kubernetes and is not available for Docker.
+
+The joblogs section contains the following parameters:
+
+  * `logs_dir`     - a directory to store log files collected on k8s cluster (implemented only for Kubernetes). If you are using a Persistent Volume, keep in mind, that the provided path should be mounted in the deployment manifest. Read and write permissions should be granted to allow actions with log files in the provided directory, thus a [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) was added to the deployment manifest.
+  * `compression_method` - a method to compress log files. Available options are `gzip` `bzip2`, `lzma`, `brotli` and `none`. If no compression_method is provided, it defaults to `none`.
+
+If you would like to provide a `compression_method` parameter, please, read the dedicated section below.
+
+### compression for joblogs
 
 When the log file was uploaded to the specified storage, the pod is labeled with org.scrapy.log_file_uploaded=true, it also
 contains labels to specify an end location of the log files in the storage.
@@ -60,25 +70,14 @@ contains a part of the end location. The labels are named as follows:
   * org.scrapy.spider
   * org.scrapy.job_id
   * org.scrapy.extension
+  * org.scrapy.compression
 
 How can you build the end location from these labels? Complete the following line
-  * logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.`org.scrapy.extension` 
+  * logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.`org.scrapy.extension`.`org.scrapy.compression` 
 
-**Important**: if you used the `compression_method` parameter, the extension of the log file then have two extensions. The
-first extension is `.log` and the second extension is extracted to the label `org.scrapy.extension`. 
-
-For example, if you used
-`compression_method = gzip`, the log file will be named as 
-  * logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.log.`org.scrapy.extension`
-
-If you haven't specified a compression method, then none was applied and the final location of the log file is
-* logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.`org.scrapy.extension`
-
-The joblogs section contains the following parameters:
-
-  * `logs_dir`     - a directory to store log files collected on k8s cluster (implemented only for Kubernetes). If you are using a Persistent Volume, keep in mind, that the provided path should be mounted in the deployment manifest. Read and write permissions should be granted to allow actions with log files in the provided directory, thus a [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) was added to the deployment manifest.
-  * `compression_method` - a method to compress log files. Available options are `gzip` `bzip2`, `lzma`, `brotli` and `none`. If no compression_method is provided, it defaults to `none`.
-
+**Important**: if you did not use the `compression_method` parameter, the label `org.scrapy.compression` has `none` value
+so the final destination of the log file will be:
+  * logs/`org.scrapy.project`/`org.scrapy.spider`/`org.scrapy.job_id`.`org.scrapy.extension`
 
 ### Kubernetes API interaction
 

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -166,6 +166,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
+    # add "patch" if you use joblogs feature
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods/exec"]

--- a/scrapyd_k8s/object_storage/libcloud_driver.py
+++ b/scrapyd_k8s/object_storage/libcloud_driver.py
@@ -133,7 +133,8 @@ class LibcloudObjectStorage:
 
         Returns
         -------
-        None
+        str or None
+            The object name in storage if upload is successful, None otherwise.
 
         Logs
         ----
@@ -172,6 +173,10 @@ class LibcloudObjectStorage:
                     f"Successfully uploaded compressed file '{object_name}' to container '{self._container_name}'.")
             else:
                 logger.info(f"Successfully uploaded file '{object_name}' to container '{self._container_name}'.")
+
+            # Return object_name on successful upload
+            return object_name
+
         except (ObjectError, ContainerDoesNotExistError, InvalidContainerNameError) as e:
             logger.exception(f"Error uploading the file '{object_name}': {e}")
         except Exception as e:


### PR DESCRIPTION
#53 
This PR adds the following changes:

A new private method was added to the KubernetesJobLogHandler class: _add_object_name_label.
This method is called after a log file from a corresponding pod was uploaded to the remote storage. This method adds an extension as a label (always the last extension of the file without a dot, so if a file was compressed, it adds a compression extension, if not, then it adds `log` extension. It also adds a label `org.scrapy.log_file_uploaded=true` to indicate that the file was successfully uploaded.

The CONFIG md has a detailed documentation on how a user can reconstruct the final destination in the remote storage to find a specific log file.