### PR TITLE
fix: set end_time on finished job

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ Lists spiders from the spider image's `org.scrapy.spiders` label.
 ### `listjobs.json` ([➽](https://scrapyd.readthedocs.io/en/latest/api.html#listjobs-json))
 
 Lists current jobs by looking at Docker containers or Kubernetes jobs.
-Note that `end_time` is not yet supported for Docker.
 
 ### ~~`delversion.json`~~ ([➽](https://scrapyd.readthedocs.io/en/latest/api.html#delversion-json))
 

--- a/scrapyd_k8s/launcher/docker.py
+++ b/scrapyd_k8s/launcher/docker.py
@@ -169,7 +169,7 @@ class Docker:
             'project': c.labels.get(self.LABEL_PROJECT),
             'spider': c.labels.get(self.LABEL_SPIDER),
             'start_time': format_iso_date_string(c.attrs['State']['StartedAt']) if state in ['running', 'finished'] else None,
-            'end_time': None,  # Not available using Docker's API. Add to the job representation to keep it the same as K8s jobs listing.
+            'end_time': format_iso_date_string(c.attrs['State']['FinishedAt']) if state in ['finished'] else None,
         }
 
     def _get_container(self, project_id, job_id):

--- a/scrapyd_k8s/tests/integration/test_api.py
+++ b/scrapyd_k8s/tests/integration/test_api.py
@@ -161,7 +161,7 @@ def test_scenario_cancel_running_finished_ok():
     jobinfo = assert_listjobs(finished=jobid)
     start_time, end_time = jobinfo.pop('start_time'), jobinfo.pop('end_time')
     assert datetime.strptime(start_time, '%Y-%m-%d %H:%M:%S.%f')
-    assert end_time is None
+    assert datetime.strptime(end_time, '%Y-%m-%d %H:%M:%S.%f')
     assert jobinfo == { 'id': jobid, 'project': RUN_PROJECT, 'spider': RUN_SPIDER, 'state': 'finished' }
     # then cancel it again, though nothing would happen
     response = requests.post(BASE_URL + '/cancel.json', data={ 'project': RUN_PROJECT, 'job': jobid })
@@ -191,7 +191,7 @@ def scenario_regular(schedule_args):
     jobinfo = assert_listjobs(finished=jobid)
     start_time, end_time = jobinfo.pop('start_time'), jobinfo.pop('end_time')
     assert datetime.strptime(start_time, '%Y-%m-%d %H:%M:%S.%f')
-    assert datetime.strptime(end_time, '%Y-%m-%d %H:%M:%S.%f') if WITH_K8S else end_time is None
+    assert datetime.strptime(end_time, '%Y-%m-%d %H:%M:%S.%f')
     assert jobinfo == { 'id': jobid, 'project': RUN_PROJECT, 'spider': RUN_SPIDER, 'state': 'finished' }
 
 def assert_response_ok(response):


### PR DESCRIPTION
Related to #40 

If a docker containers finishes, its attributes will contain a field FinishedAt.

When /listjobs.json is called, the function api_listjobs() in api.py is called. This function in turn will call the listjobs() function in docker.py. In this function a docker client is called to list all processes. The docker library function does the same as ```docker ps -a```. Then each of these jobs are parsed by the _parse_job() function. Here certain labels and attributes are grabbed and set. Since the FinishedAt field is available, we can grab this and use it to set the end_time field.

To test the functionality the github workflows setup the environment and run tests when pushed to main or a pr is created. The test-docker part succeeds, but the manifest and k8 part fail on the last test ```test_scenario_cancel_running_finished_ok```. The test-manifest step fails somewhere unrelated to to changed files, so more research is needed as to why the assert fails. The test-k8s does fail on a related part, ```assert datetime.strptime(end_time, '%Y-%m-%d %H:%M:%S.%f')```. This logic however is unchanged, so still unclear what the reason for this is. Previously the assert was ```assert end_time is None```, however I suspect that this assert was wrong. After a job is finished the end_time should be available. The assert probably fails, because the line ``` 'end_time': format_datetime_object(job.status.completion_time) if job.status.completion_time and state == 'finished' else None,
``` in k8s.py. The end time doesn't just get set if the state is set to finished, but also if ```job.status.completion_time.```