### PR TITLE
Add basic joblogs integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,12 +143,12 @@ jobs:
             # wait for scrapyd-k8s to become ready
             kubectl wait --for=condition=Available deploy/scrapyd-k8s --timeout=60s
             curl -s --retry 10 --retry-delay 2 --retry-all-errors `minikube service scrapyd-k8s --url`/daemonstatus.json
-            # run test
+            # run test (and show logs on test failure)
             TEST_WITH_K8S=1 \
               TEST_BASE_URL=`minikube service scrapyd-k8s --url` \
               TEST_MAX_WAIT=60 \
               TEST_AVAILABLE_VERSIONS=latest,`skopeo list-tags docker://ghcr.io/q-m/scrapyd-k8s-spider-example | jq -r '.Tags | map(select(. != "latest" and (startswith("sha-") | not))) | join(",")'` \
-              pytest -vv --color=yes "$test"
+              pytest -vv --color=yes "$test" || (kubectl logs deploy/scrapyd-k8s && false)
             # delete al jobs to start with a clean slate next time
             kubectl delete job --all
             # stop scrapyd-k8s and delete test-specific configmap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
         run: |
           for test in scrapyd_k8s/tests/integration/test_*.py; do
             echo; echo "# $test"
+            localconfig=`echo "$test" | sed 's/\.py$/\.local.sh/'`
+            [ -x "$localconfig" ] && "$localconfig" up || true
             # run scrapyd-k8s with test-specific configuration file
             cfg=`echo "$test" | sed 's/\.py$/.conf/'`
             python -m scrapyd_k8s -c scrapyd_k8s.sample-docker.conf -c "$cfg" &
@@ -59,6 +61,8 @@ jobs:
             pytest -vv --color=yes "$test"
             # stop scrapyd-k8s again
             kill %1; wait %1 || true
+            # cleanup
+            [ -x "$localconfig" ] && "$localconfig" down || true
           done
 
   test-manifest:
@@ -128,15 +132,13 @@ jobs:
 
       - name: Run tests
         run: |
-          # setup for in-cluster k8s
-          # for each integration test file
           for test in scrapyd_k8s/tests/integration/test_*.py; do
             echo; echo "# $test"
             # run scrapyd-k8s with test-specific configuration file, run k8s patch if available
             cfg=`echo "$test" | sed 's/\.py$/.conf/'`
             kubectl create cm scrapyd-k8s-testcfg --from-file=scrapyd_k8s.test.conf="$cfg"
             k8sconfig=`echo "$test" | sed 's/\.py$/\.k8s.sh/'`
-            [ -x "$k8sconfig" ] && "$k8sconfig" up
+            [ -x "$k8sconfig" ] && "$k8sconfig" up || true
             kubectl scale --replicas=1 deploy/scrapyd-k8s
             # wait for scrapyd-k8s to become ready
             kubectl wait --for=condition=Available deploy/scrapyd-k8s --timeout=60s
@@ -153,7 +155,7 @@ jobs:
             kubectl scale --replicas=0 deploy/scrapyd-k8s
             kubectl wait --for=delete pod -l app.kubernetes.io/name=scrapyd-k8s --timeout=90s
             kubectl delete cm scrapyd-k8s-testcfg --wait
-            [ -x "$k8sconfig" ] && "$k8sconfig" down
+            [ -x "$k8sconfig" ] && "$k8sconfig" down || true
           done
 
   test-k8s:
@@ -188,6 +190,8 @@ jobs:
         run: |
           for test in scrapyd_k8s/tests/integration/test_*.py; do
             echo "# $test"
+            localconfig=`echo "$test" | sed 's/\.py$/\.local.sh/'`
+            [ -x "$localconfig" ] && "$localconfig" up || true
             # run scrapyd-k8s with test-specific configuration file
             cfg=`echo "$test" | sed 's/\.py$/.conf/'`
             [ -e "$cfg" ] || cfg=/dev/null
@@ -201,4 +205,6 @@ jobs:
               pytest -vv --color=yes "$test"
             # stop scrapyd-k8s again
             kill %1; wait %1 || true
+            # cleanup
+            [ -x "$localconfig" ] && "$localconfig" down || true
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as base
+FROM python:3.11-slim AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends skopeo && \

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -104,9 +104,6 @@ data:
     requests_memory = 0.2G
     limits_cpu = 0.8
     limits_memory = 0.5G
-    
-    [joblogs]
-    logs_dir = /data/joblogs
 ---
 apiVersion: v1
 kind: Secret
@@ -169,7 +166,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods/exec"]
-    verbs: ["get"]
+    verbs: ["get", "create"]
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 docker>=5.0.0
-kubernetes>=27.2.0 # introduction of suspend in jobspec
+kubernetes>=27.2.0,<36.0.0 # introduction of suspend in jobspec; 36 has issues with joblogs
 flask>=2.0.0
 natsort>=8.0.0
 Flask-BasicAuth>=0.2.0
 MarkupSafe>=2.1.5
 apache-libcloud>=3.8.0
+fasteners>=0.20 # for libcloud local provider
 brotli>=1.1.0 # only if you plan to use brotli compression for log files in joblogs module

--- a/scrapyd_k8s/tests/integration/test_joblogs.conf
+++ b/scrapyd_k8s/tests/integration/test_joblogs.conf
@@ -1,0 +1,8 @@
+# additional scrapyd-k8s configuration for test_joblogs.py
+[joblogs]
+logs_dir = /tmp/joblogs/live
+storage_provider = local
+container_name = a
+
+[joblogs.storage.local]
+key = /tmp/joblogs/container

--- a/scrapyd_k8s/tests/integration/test_joblogs.k8s.sh
+++ b/scrapyd_k8s/tests/integration/test_joblogs.k8s.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Kubernetes cluster preparation for test_joblogs.py
+# Called with "up" argument on setup, with "down" argument afterwards.
+#
+# Creates the joblogs container path before starting the pod.
+# Tightly bound to kubernetes.yaml.
+# Assumes no minikind mounts are active.
+# Assumes scrapy container runs as user nobody (uid 65534).
+
+if [ "$1" = "up" ]; then
+  mkdir -p /tmp/joblogs/container/a
+  mkdir -p /tmp/joblogs/live
+  minikube mount /tmp/joblogs:/tmp/joblogs --uid=65534 &
+  kubectl patch deploy scrapyd-k8s --type=json -p='[
+    {
+      "op": "add",
+      "path": "/spec/template/spec/volumes/0",
+      "value": {
+        "name": "joblogs",
+        "hostPath": {
+          "path": "/tmp/joblogs"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/spec/template/spec/containers/0/volumeMounts/0",
+      "value": {
+        "mountPath": "/tmp/joblogs",
+        "name": "joblogs"
+      }
+    }
+  ]'
+elif [ "$1" = "down" ]; then
+  kubectl patch deploy scrapyd-k8s --type=json -p='[
+    {
+      "op": "remove",
+      "path": "/spec/template/spec/containers/0/volumeMounts/0"
+    },
+    {
+      "op": "remove",
+      "path": "/spec/template/spec/volumes/0"
+    }
+  ]'
+  minikube mount --kill=true
+  rm -Rf /tmp/joblogs
+else
+  echo "Usage: $0 up|down"
+  exit 1
+fi

--- a/scrapyd_k8s/tests/integration/test_joblogs.local.sh
+++ b/scrapyd_k8s/tests/integration/test_joblogs.local.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Environment preparation for test_joblogs.py (all test configurations).
+# Called with "up" argument on setup, with "down" argument afterwards.
+#
+# Creates the joblogs container paths, as it is required to start scrapyd-k8s.
+
+if [ "$1" = "up" ]; then
+  mkdir -p /tmp/joblogs/container/a
+  mkdir -p /tmp/joblogs/live
+elif [ "$1" = "down" ]; then
+  rm -Rf /tmp/joblogs
+else
+  echo "Usage: $0 up|down"
+  exit 1
+fi

--- a/scrapyd_k8s/tests/integration/test_joblogs.py
+++ b/scrapyd_k8s/tests/integration/test_joblogs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import os
+import pytest
+import requests
+import shutil
+import time
+
+BASE_URL = os.getenv('TEST_BASE_URL', 'http://localhost:6800')
+RUN_PROJECT = os.getenv('TEST_RUN_PROJECT', 'example')
+RUN_VERSION = os.getenv('TEST_RUN_VERSION', 'latest')
+RUN_SPIDER = os.getenv('TEST_RUN_SPIDER', 'static')
+MAX_WAIT = int(os.getenv('TEST_MAX_WAIT', '6'))
+STATIC_SLEEP = float(os.getenv('TEST_STATIC_SLEEP', '2'))
+WITH_K8S = bool(os.getenv('TEST_WITH_K8S'))
+LOG_BASE = os.getenv('TEST_LOG_BASE', '/tmp/joblogs')
+
+LOG_DIR_LIVE = os.path.join(LOG_BASE, 'live')
+LOG_DIR_CONT = os.path.join(LOG_BASE, 'container', 'a')
+
+@pytest.mark.skipif(not WITH_K8S, reason="joblogs only implemented for Kubernetes")
+def test_live():
+  # Schedule a job
+  response = requests.post(BASE_URL + '/schedule.json', data={
+      'project': RUN_PROJECT, 'spider': RUN_SPIDER, '_version': RUN_VERSION,
+      'setting': 'STATIC_SLEEP=%d' % STATIC_SLEEP
+  })
+  assert_response_ok(response)
+  jobid = response.json()['jobid']
+  assert jobid is not None
+  # Make sure the job is running
+  listjobs_wait(jobid, 'running')
+
+  # Check that log file is present and has sensible content
+  log_path_live = os.path.join(LOG_DIR_LIVE, jobid + '.txt')
+  assert(os.path.isfile(log_path_live))
+  with open(log_path_live, 'r') as f:
+    assert('(bot: %s)' % RUN_PROJECT in f.read(2048))
+
+  # Wait until finished
+  listjobs_wait(jobid, 'finished', max_wait=STATIC_SLEEP+MAX_WAIT)
+
+@pytest.mark.skipif(not WITH_K8S, reason="joblogs only implemented for Kubernetes")
+def test_container():
+  # Schedule a job
+  response = requests.post(BASE_URL + '/schedule.json', data={
+      'project': RUN_PROJECT, 'spider': RUN_SPIDER, '_version': RUN_VERSION,
+      'setting': 'STATIC_SLEEP=%d' % STATIC_SLEEP
+  })
+  assert_response_ok(response)
+  jobid = response.json()['jobid']
+  assert jobid is not None
+
+  # Wait until finished, and a bit more to finish log processing
+  listjobs_wait(jobid, 'finished', max_wait=STATIC_SLEEP+MAX_WAIT)
+  time.sleep(1)
+
+  # Make sure we find logfile in container storage (configured as local storage)
+  log_path_cont = os.path.join(LOG_DIR_CONT, 'logs', RUN_PROJECT, RUN_SPIDER, jobid + '.log')
+  assert(os.path.isfile(log_path_cont))
+  with open(log_path_cont, 'r') as f:
+    log = f.read()
+    # bot name in first lines
+    assert('(bot: %s)' % RUN_PROJECT in log)
+    # 'Spider finished' in last lines
+    assert('Spider closed (finished)' in log)
+
+def assert_response_ok(response):
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json()['status'] == 'ok'
+
+def listjobs_wait(jobid, state, max_wait=MAX_WAIT):
+    started = time.monotonic()
+    while time.monotonic() - started < max_wait:
+        response = requests.get(BASE_URL + '/listjobs.json')
+        assert_response_ok(response)
+        for j in response.json()[state]:
+            if j['id'] == jobid:
+                return True
+        time.sleep(0.5)
+    assert False, 'Timeout waiting for job state change'

--- a/scrapyd_k8s/tests/integration/test_joblogs_gzip.conf
+++ b/scrapyd_k8s/tests/integration/test_joblogs_gzip.conf
@@ -1,0 +1,9 @@
+# additional scrapyd-k8s configuration for test_joblogs.py
+[joblogs]
+logs_dir = /tmp/joblogs/live
+storage_provider = local
+container_name = a
+compression_method = gzip
+
+[joblogs.storage.local]
+key = /tmp/joblogs/container

--- a/scrapyd_k8s/tests/integration/test_joblogs_gzip.k8s.sh
+++ b/scrapyd_k8s/tests/integration/test_joblogs_gzip.k8s.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Kubernetes cluster preparation for test_joblogs_gzip.py
+# Called with "up" argument on setup, with "down" argument afterwards.
+#
+# Creates the joblogs container path before starting the pod.
+# Tightly bound to kubernetes.yaml
+# Assumes no minikind mounts are active.
+# Assumes scrapy container runs as user nobody (uid 65534).
+
+if [ "$1" = "up" ]; then
+  mkdir -p /tmp/joblogs/container/a
+  mkdir -p /tmp/joblogs/live
+  minikube mount /tmp/joblogs:/tmp/joblogs --uid=65534 &
+  kubectl patch deploy scrapyd-k8s --type=json -p='[
+    {
+      "op": "add",
+      "path": "/spec/template/spec/volumes/0",
+      "value": {
+        "name": "joblogs",
+        "hostPath": {
+          "path": "/tmp/joblogs"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/spec/template/spec/containers/0/volumeMounts/0",
+      "value": {
+        "mountPath": "/tmp/joblogs",
+        "name": "joblogs"
+      }
+    }
+  ]'
+elif [ "$1" = "down" ]; then
+  kubectl patch deploy scrapyd-k8s --type=json -p='[
+    {
+      "op": "remove",
+      "path": "/spec/template/spec/containers/0/volumeMounts/0"
+    },
+    {
+      "op": "remove",
+      "path": "/spec/template/spec/volumes/0"
+    }
+  ]'
+  minikube mount --kill=true
+  rm -Rf /tmp/joblogs
+else
+  echo "Usage: $0 up|down"
+  exit 1
+fi

--- a/scrapyd_k8s/tests/integration/test_joblogs_gzip.local.sh
+++ b/scrapyd_k8s/tests/integration/test_joblogs_gzip.local.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Environment preparation for test_joblogs.py (all test configurations).
+# Called with "up" argument on setup, with "down" argument afterwards.
+#
+# Creates the joblogs container paths, as it is required to start scrapyd-k8s.
+
+if [ "$1" = "up" ]; then
+  mkdir -p /tmp/joblogs/container/a
+  mkdir -p /tmp/joblogs/live
+elif [ "$1" = "down" ]; then
+  rm -Rf /tmp/joblogs
+else
+  echo "Usage: $0 up|down"
+  exit 1
+fi
+

--- a/scrapyd_k8s/tests/integration/test_joblogs_gzip.py
+++ b/scrapyd_k8s/tests/integration/test_joblogs_gzip.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import gzip
+import os
+import pytest
+import requests
+import shutil
+import time
+
+BASE_URL = os.getenv('TEST_BASE_URL', 'http://localhost:6800')
+RUN_PROJECT = os.getenv('TEST_RUN_PROJECT', 'example')
+RUN_VERSION = os.getenv('TEST_RUN_VERSION', 'latest')
+RUN_SPIDER = os.getenv('TEST_RUN_SPIDER', 'static')
+MAX_WAIT = int(os.getenv('TEST_MAX_WAIT', '6'))
+STATIC_SLEEP = float(os.getenv('TEST_STATIC_SLEEP', '2'))
+WITH_K8S = bool(os.getenv('TEST_WITH_K8S'))
+LOG_BASE = os.getenv('TEST_LOG_BASE', '/tmp/joblogs')
+
+LOG_DIR_LIVE = os.path.join(LOG_BASE, 'live')
+LOG_DIR_CONT = os.path.join(LOG_BASE, 'container', 'a')
+
+@pytest.mark.skipif(not WITH_K8S, reason="joblogs only implemented for Kubernetes")
+def test_container():
+  # Schedule a job
+  response = requests.post(BASE_URL + '/schedule.json', data={
+      'project': RUN_PROJECT, 'spider': RUN_SPIDER, '_version': RUN_VERSION,
+      'setting': 'STATIC_SLEEP=%d' % STATIC_SLEEP
+  })
+  assert_response_ok(response)
+  jobid = response.json()['jobid']
+  assert jobid is not None
+
+  # Wait until finished, and a bit more to finish log processing
+  listjobs_wait(jobid, 'finished', max_wait=STATIC_SLEEP+MAX_WAIT)
+  time.sleep(1)
+
+  # Make sure we find logfile in container storage (configured as local storage)
+  log_path_cont = os.path.join(LOG_DIR_CONT, 'logs', RUN_PROJECT, RUN_SPIDER, jobid + '.log.gz')
+  assert(os.path.isfile(log_path_cont))
+  with gzip.open(log_path_cont, 'rb') as f:
+    log = f.read().decode('utf-8')
+    # bot name in first lines
+    assert('(bot: %s)' % RUN_PROJECT in log)
+    # 'Spider finished' in last lines
+    assert('Spider closed (finished)' in log)
+
+def assert_response_ok(response):
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json()['status'] == 'ok'
+
+def listjobs_wait(jobid, state, max_wait=MAX_WAIT):
+    started = time.monotonic()
+    while time.monotonic() - started < max_wait:
+        response = requests.get(BASE_URL + '/listjobs.json')
+        assert_response_ok(response)
+        for j in response.json()[state]:
+            if j['id'] == jobid:
+                return True
+        time.sleep(0.5)
+    assert False, 'Timeout waiting for job state change'


### PR DESCRIPTION
Implements #33.

- [x] Test during spider run (logs read)
- [x] Test move to container storage
- [x] Skip for Docker (as only implemented for Kubernetes right now)

Additional tests:
- [x] Test compression method(s) (added `gzip` only now)
- [x] ~~Test whether joblogs recovers from an interrupted stream~~ -> for later